### PR TITLE
Modified constructor to take JSON string instead of Dictionary

### DIFF
--- a/src/SemanticLogging.Elasticsearch/Configuration/ElasticsearchSinkElement.cs
+++ b/src/SemanticLogging.Elasticsearch/Configuration/ElasticsearchSinkElement.cs
@@ -37,7 +37,8 @@ namespace FullScale180.SemanticLogging.Configuration
                 bufferInterval == null ? Buffering.DefaultBufferingInterval : bufferInterval.Value,
                 (int?)element.Attribute("bufferingCount") ?? Buffering.DefaultBufferingCount,
                 (int?)element.Attribute("maxBufferSize") ?? Buffering.DefaultMaxBufferSize,
-                element.Attribute("bufferingFlushAllTimeoutInSeconds").ToTimeSpan() ?? Constants.DefaultBufferingFlushAllTimeout);
+                element.Attribute("bufferingFlushAllTimeoutInSeconds").ToTimeSpan() ?? Constants.DefaultBufferingFlushAllTimeout,
+                (string)element.Attribute("jsonGlobalContextExtension"));
         }
     }
 }

--- a/src/SemanticLogging.Elasticsearch/ElasticsearchLog.cs
+++ b/src/SemanticLogging.Elasticsearch/ElasticsearchLog.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using FullScale180.SemanticLogging.Sinks;
 using Microsoft.Practices.EnterpriseLibrary.SemanticLogging;
 using Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Utility;
+using Newtonsoft.Json;
 
 namespace FullScale180.SemanticLogging
 {
@@ -29,7 +30,7 @@ namespace FullScale180.SemanticLogging
         /// This means that if the timeout period elapses, some event entries will be dropped and not sent to the store. Normally, calling <see cref="IDisposable.Dispose" /> on
         /// the <see cref="System.Diagnostics.Tracing.EventListener" /> will block until all the entries are flushed or the interval elapses.
         /// If <see langword="null" /> is specified, then the call will block indefinitely until the flush operation finishes.</param>
-        /// <param name="globalContextExtension">A dictionary of user defined keys and values to be attached to each log.</param>
+        /// <param name="globalContextExtension">A json dictionary of user defined keys and values to be attached to each log.</param>
         /// <returns>
         /// A subscription to the sink that can be disposed to unsubscribe the sink and dispose it, or to get access to the sink instance.
         /// </returns>
@@ -38,19 +39,19 @@ namespace FullScale180.SemanticLogging
             TimeSpan? onCompletedTimeout = null,
             int bufferingCount = Buffering.DefaultBufferingCount,
             int maxBufferSize = Buffering.DefaultMaxBufferSize,
-            Dictionary<string, string> globalContextExtension = null)
+            Dictionary<string,string> globalContextExtension = null)
         {
             var sink = new ElasticsearchSink(instanceName, connectionString, index, type, flattenPayload,
                 bufferingInterval ?? Buffering.DefaultBufferingInterval,
                 bufferingCount,
                 maxBufferSize,
                 onCompletedTimeout ?? Timeout.InfiniteTimeSpan,
-                globalContextExtension);
+                JsonConvert.SerializeObject(globalContextExtension));
 
             var subscription = eventStream.Subscribe(sink);
             return new SinkSubscription<ElasticsearchSink>(subscription, sink);
         }
-
+        
         /// <summary>
         /// Creates an event listener that logs using a <see cref="ElasticsearchSink" />.
         /// </summary>

--- a/src/SemanticLogging.Elasticsearch/ElasticsearchLog.cs
+++ b/src/SemanticLogging.Elasticsearch/ElasticsearchLog.cs
@@ -30,7 +30,7 @@ namespace FullScale180.SemanticLogging
         /// This means that if the timeout period elapses, some event entries will be dropped and not sent to the store. Normally, calling <see cref="IDisposable.Dispose" /> on
         /// the <see cref="System.Diagnostics.Tracing.EventListener" /> will block until all the entries are flushed or the interval elapses.
         /// If <see langword="null" /> is specified, then the call will block indefinitely until the flush operation finishes.</param>
-        /// <param name="globalContextExtension">A json dictionary of user defined keys and values to be attached to each log.</param>
+        /// <param name="globalContextExtension">A dictionary of user defined keys and values to be attached to each log.</param>
         /// <returns>
         /// A subscription to the sink that can be disposed to unsubscribe the sink and dispose it, or to get access to the sink instance.
         /// </returns>


### PR DESCRIPTION
Modified the ElasticsearchSink constructor to take an optional JSON string instead of a Dictionary which caused a Method Does Not Exist error upon sink creation.